### PR TITLE
Fixed bug w/ localStorage in cart + added price totaling

### DIFF
--- a/client/components/Cart.js
+++ b/client/components/Cart.js
@@ -17,7 +17,7 @@ export class Cart extends Component {
     //If not, pull it out of local storage
     let productArr = [];
     for(let i = 0; i < localStorage.length; i++){
-      if(localStorage.key(i) !== 'token'){
+      if(localStorage.key(i).includes('product')){
         productArr.push(JSON.parse(localStorage.getItem(localStorage.key(i))))
       }
     }
@@ -82,7 +82,11 @@ export class Cart extends Component {
            })
           }
         </ul>
-        <div className="right">Subtotal({this.state.productArr.length} of Items): $100</div>
+        <div className="right">Subtotal({this.state.productArr.length} of Items):$ {
+        this.state.productArr !== [] ? this.state.productArr.reduce(function(prev, curr){
+          return prev + curr.liquorTotalPrice
+        }, 0) : <h1>'$0'</h1>
+      }</div>
       </div>
     );
   }

--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -39,7 +39,7 @@ class SingleProduct extends React.Component {
   handleAddToCart(e, product, quantity){
     if(this.state.error === ''){
       let key = 'product'+product.id.toString();
-
+      localStorage.removeItem('TEST');
       let itemAddedToCart = {
         ...product,
         liquorQuantity: quantity,


### PR DESCRIPTION
Issue:

- There was a conditional in Cart.js when transferring products from localStorage to local state that would only push items to the state array if their key wasn't 'token'. This would break the Cart page if there was anything in the users localStorage with a key that wasn't 'token' but that was also not stringified JSON (i.e. that weird webpack thing).

Solution:

- Updated the conditional to check if the key contains 'product' which is appended to the product ID when setting up an item in local storage. If yes, add that item to state. If no, do nothing.

Additionally, this PR contains an update to the cart page that totals the price of the cart.